### PR TITLE
Hostmanager entries required in different section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ invade.yml
 Vagrantfile
 Vagrantfile.new
 .vagrant
+pkg

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ end
 
 group :plugins do
   gem "vagrant-invade", path: "."
+  gem "vagrant-hostmanager", git: "https://github.com/smdahlen/vagrant-hostmanager.git"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,10 +20,16 @@ GIT
       winrm (~> 1.3)
       winrm-fs (~> 0.2.2)
 
+GIT
+  remote: https://github.com/smdahlen/vagrant-hostmanager.git
+  revision: 2325313b4ea7d032f90d200a02cf1163d877019c
+  specs:
+    vagrant-hostmanager (1.6.1)
+
 PATH
   remote: .
   specs:
-    vagrant-invade (0.4.6)
+    vagrant-invade (0.4.7)
 
 GEM
   remote: https://rubygems.org/
@@ -100,6 +106,7 @@ PLATFORMS
 
 DEPENDENCIES
   vagrant!
+  vagrant-hostmanager!
   vagrant-invade!
 
 BUNDLED WITH

--- a/lib/vagrant-invade/action/generate.rb
+++ b/lib/vagrant-invade/action/generate.rb
@@ -23,6 +23,7 @@ module VagrantPlugins
           unless machines == nil
 
             part = Hash.new
+            part['header'] = ''
             definition = Hash.new
 
             machines.each_with_index do |(machine, section), index|
@@ -76,8 +77,12 @@ module VagrantPlugins
                 part['plugin'] = ''
 
                 section['plugin'].each do |type, data|
-                  parts = Generator::Section::Plugin.new(machine, @env[:ui], type, data).generate
-                  part['plugin'].concat(parts)
+                  if type == 'hostmanager'
+                    part['header'].concat(Generator::Section::Plugin.new(machine, @env[:ui], type, data).generate)
+                  else
+                    parts = Generator::Section::Plugin.new(machine, @env[:ui], type, data).generate
+                    part['plugin'].concat(parts)
+                  end
                 end
               end
 

--- a/lib/vagrant-invade/builder/definition.rb
+++ b/lib/vagrant-invade/builder/definition.rb
@@ -25,6 +25,7 @@ module VagrantPlugins
             machine_name = @machine_name
 
             # Data to build definition entry
+            header = @definition_data['header']
             vm = @definition_data['vm']
             network = @definition_data['network']
             provider = @definition_data['provider']

--- a/lib/vagrant-invade/builder/plugin/hostmanager.rb
+++ b/lib/vagrant-invade/builder/plugin/hostmanager.rb
@@ -8,10 +8,9 @@ module VagrantPlugins
         class HostManager
 
           attr_reader :result
-          attr_accessor :machine_name, :ui, :hostmanager_data
+          attr_accessor :ui, :hostmanager_data
 
-          def initialize(machine_name, ui, hostmanager_data, result: nil)
-            @machine_name = machine_name
+          def initialize(ui, hostmanager_data, result: nil)
             @hostmanager_data = hostmanager_data
             @ui = ui
             @result = result
@@ -28,9 +27,6 @@ module VagrantPlugins
               template_file = "#{TEMPLATE_PATH}/plugin/hostmanager.erb"
 
               begin
-
-                # Get machine name
-                machine_name = @machine_name
 
                 # Values for hostmanager section
                 enabled = @hostmanager_data['enabled']

--- a/lib/vagrant-invade/generator/section/plugin.rb
+++ b/lib/vagrant-invade/generator/section/plugin.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
           def generate
             case @type
             when 'hostmanager'
-              plugin = Builder::Plugin::HostManager.new(@machine_name, @ui, @plugin_data)
+              plugin = Builder::Plugin::HostManager.new(@ui, @plugin_data)
             when 'winnfsd'
               plugin = Builder::Plugin::WinNFSd.new(@machine_name, @ui, @plugin_data)
             when 'r10k'

--- a/lib/vagrant-invade/template/definition.erb
+++ b/lib/vagrant-invade/template/definition.erb
@@ -1,3 +1,6 @@
+<% if header %>
+<%= header %>
+<% end %>
 config.vm.define "<%= machine_name %>" do |<%= machine_name %>|
 
   <% if vm %>
@@ -21,7 +24,7 @@ config.vm.define "<%= machine_name %>" do |<%= machine_name %>|
   <%= provision %>
   <% end %>
   <% if plugin %>
-    # --- Plugin Section
+    # --- Plugin Section ---
   <%= plugin %>
   <% end %>
   end

--- a/lib/vagrant-invade/template/plugin/hostmanager.erb
+++ b/lib/vagrant-invade/template/plugin/hostmanager.erb
@@ -1,15 +1,15 @@
-  <% if enabled %>
-  <%= machine_name %>.hostmanager.enabled = <%= enabled %>
-    <% end %>
-    <% if manage_host %>
-    <%= machine_name %>.hostmanager.manage_host = <%= manage_host %>
-    <% end %>
-    <% if ignore_private_ip %>
-    <%= machine_name %>.hostmanager.ignore_private_ip = <%= ignore_private_ip %>
-    <% end %>
-    <% if include_offline %>
-    <%= machine_name %>.hostmanager.include_offline = <%= include_offline %>
-    <% end %>
-    <% if aliases %>
-    <%= machine_name %>.hostmanager.aliases = <%= aliases %>
-    <% end %>
+<% if enabled %>
+config.hostmanager.enabled = <%= enabled %>
+<% end %>
+<% if manage_host %>
+config.hostmanager.manage_host = <%= manage_host %>
+<% end %>
+<% if ignore_private_ip %>
+config.hostmanager.ignore_private_ip = <%= ignore_private_ip %>
+<% end %>
+<% if include_offline %>
+config.hostmanager.include_offline = <%= include_offline %>
+<% end %>
+<% if aliases %>
+config.hostmanager.aliases = <%= aliases %>
+<% end %>


### PR DESCRIPTION
The entries of the host manager plugin section needed in the head of the vagrant file. Otherwise they have no effect.
